### PR TITLE
Add Apple Chip Type Property

### DIFF
--- a/GetiOSModel.csproj
+++ b/GetiOSModel.csproj
@@ -64,11 +64,13 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="iOSHardware.cs" />
     <Compile Include="Xamarin.iOS.DeviceHardware.cs" />
+    <Compile Include="iOSChipType.cs" />
+    <Compile Include="iOSChipTypeMap.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="README.md" />
     <None Include="packages.config" />
-    <None Include="LICENSE.txt" Pack="true" PackagePath="$(PackageLicenseFile)"/>
+    <None Include="LICENSE.txt" Pack="true" PackagePath="$(PackageLicenseFile)" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
   <Import Project=".\packages\NuGet.Build.Packaging.0.1.324\build\NuGet.Build.Packaging.targets" Condition="Exists('.\packages\NuGet.Build.Packaging.0.1.324\build\NuGet.Build.Packaging.targets')" />

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Will keep repository updated as new devices become available.
 If you need an Android library check out my other repo https://github.com/dannycabrera/GetDroidModel.
 
 Updates:<br/>
+05/09/2019 - Added Apple Chip Type property<br/>
 06/01/2019 - Added iPod touch 7th generation<br/>
 03/27/2019 - Added 2019 iPad models: iPad mini 5 and iPad Air 3<br/>
 11/07/2018 - iPad Pro 11-inch whitespace character fix thanks to @adamzucchi<br/>
@@ -62,7 +63,13 @@ Console.WriteLine(Xamarin.iOS.DeviceHardware.Model);
 
 Result: "iPhone 5C GSM"
 
+```
+Console.WriteLine(Xamarin.iOS.DeviceHardware.ChipType);
+```
+
+Result: "A6"
+
 *******
 Thanks to:
 -------
-@sven-s, @manishkungwani, @jimbobbennett and @adamzucchi for their pull requests.
+@sven-s, @manishkungwani, @jimbobbennett, @adamzucchi and @follesoe for their pull requests.

--- a/Xamarin.iOS.DeviceHardware.cs
+++ b/Xamarin.iOS.DeviceHardware.cs
@@ -5,8 +5,8 @@ using ObjCRuntime;
 
 namespace Xamarin.iOS
 {
-	[Preserve(AllMembers = true)]
-	public static class DeviceHardware
+    [Preserve(AllMembers = true)]
+    public static class DeviceHardware
     {
         private const string HardwareProperty = "hw.machine";
 
@@ -56,20 +56,38 @@ namespace Xamarin.iOS
             }
 
             return "Unknown";
-		}
+        }
 
         public static string Version => FindVersion();
+
+        private static iOSChipType ChipType
+        {
+            get
+            {
+                var v = Version;
+                if (IsSimulator(v))
+                {
+                    return _hardwareMapper.GetChipType(SimulatorModel);
+                }
+                return _hardwareMapper.GetChipType(v);
+            }
+        }
+
         public static string Model
         {
             get
             {
                 var v = Version;
-
-                if (v == "i386" || v == "x86_64")
-                    return _hardwareMapper.GetModel(NSProcessInfo.ProcessInfo.Environment["SIMULATOR_MODEL_IDENTIFIER"].ToString()) + " Simulator";
-                else
-                    return _hardwareMapper.GetModel(v);
+                if (IsSimulator(v))
+                {
+                    return _hardwareMapper.GetModel(SimulatorModel) + " Simulator";
+                }
+                return _hardwareMapper.GetModel(v);
             }
         }
+
+        private static bool IsSimulator(string v) => v == "i386" || v == "x86_64";
+
+        private static string SimulatorModel => NSProcessInfo.ProcessInfo.Environment["SIMULATOR_MODEL_IDENTIFIER"].ToString();
     }
 }

--- a/iOSChipType.cs
+++ b/iOSChipType.cs
@@ -1,0 +1,22 @@
+﻿namespace Xamarin.iOS
+{
+    public enum iOSChipType
+    {
+        Unknown,
+        A4,
+        A5,
+        A5X,
+        A6,
+        A6X,
+        A7,
+        A8,
+        A8X,
+        A9,
+        A9X,
+        A10Fusion,
+        A10XFusion,
+        A11Bionic,
+        A12Bionic,
+        A12XBionic
+    }
+}

--- a/iOSChipTypeMap.cs
+++ b/iOSChipTypeMap.cs
@@ -1,0 +1,111 @@
+﻿using System.Collections.Generic;
+using Foundation;
+
+namespace Xamarin.iOS
+{
+    [Preserve(AllMembers = true)]
+    internal class iOSChipTypeMap : Dictionary<string, iOSChipType>
+    {
+        private readonly Dictionary<string, iOSChipType> modelChipMap;
+
+        public iOSChipTypeMap()
+        {
+            modelChipMap = new Dictionary<string, iOSChipType>
+            {
+                { "iPhone1,1", iOSChipType.A4 }, // iPhone
+                { "iPhone1,2", iOSChipType.A4 }, // iPhone 3G
+                { "iPhone2,1", iOSChipType.A4 }, // iPhone 3GS
+                { "iPhone3,1", iOSChipType.A4 }, // iPhone 4 GSM
+                { "iPhone3,2", iOSChipType.A4 }, // iPhone 4 GSM
+                { "iPhone3,3", iOSChipType.A4 }, // iPhone 4 CDMA
+                { "iPhone4,1", iOSChipType.A5 }, // iPhone 4S
+                { "iPhone5,1", iOSChipType.A6 }, // iPhone 5 GSM
+                { "iPhone5,2", iOSChipType.A6 }, // iPhone 5 Global
+                { "iPhone5,3", iOSChipType.A6 }, // iPhone 5C GSM
+                { "iPhone5,4", iOSChipType.A6 }, // iPhone 5C Global,
+                { "iPhone6,1", iOSChipType.A7 }, // iPhone 5S GSM
+                { "iPhone6,2", iOSChipType.A7 }, // iPhone 5S Global
+                { "iPhone7,1", iOSChipType.A8 }, // iPhone 6 Plus
+                { "iPhone7,2", iOSChipType.A8 }, // iPhone 6
+                { "iPhone8,1", iOSChipType.A9 }, // iPhone 6S,
+                { "iPhone8,2", iOSChipType.A9 }, // iPhone 6S Plus,
+                { "iPhone8,4", iOSChipType.A9 }, // iPhone SE,
+                { "iPhone9,1", iOSChipType.A10Fusion }, // iPhone 7
+                { "iPhone9,2", iOSChipType.A10Fusion }, // iPhone 7 Plus
+                { "iPhone9,3", iOSChipType.A10Fusion }, // iPhone 7
+                { "iPhone9,4", iOSChipType.A10Fusion }, // iPhone 7 Plus
+                { "iPhone10,1", iOSChipType.A11Bionic }, // iPhone 8
+                { "iPhone10,2", iOSChipType.A11Bionic }, // iPhone 8 Plus
+                { "iPhone10,3", iOSChipType.A11Bionic }, // iPhone X
+                { "iPhone10,4", iOSChipType.A11Bionic }, // iPhone 8
+                { "iPhone10,5", iOSChipType.A11Bionic }, // iPhone 8 Plus
+                { "iPhone10,6", iOSChipType.A11Bionic }, // iPhone X
+                { "iPhone11,2", iOSChipType.A12Bionic }, // iPhone XS
+                { "iPhone11,4", iOSChipType.A12Bionic }, // iPhone XS Max
+                { "iPhone11,6", iOSChipType.A12Bionic }, // iPhone XS Max
+                { "iPhone11,8", iOSChipType.A12Bionic }, // iPhone XR
+                { "iPad1,1", iOSChipType.A4 }, // iPad
+                { "iPad2,1", iOSChipType.A5 }, // iPad 2 Wi-Fi
+                { "iPad2,2", iOSChipType.A5 }, // iPad 2 GSM
+                { "iPad2,3", iOSChipType.A5 }, // iPad 2 CDMA
+                { "iPad2,4", iOSChipType.A5 }, // iPad 2 Wi-Fi
+                { "iPad2,5", iOSChipType.A5 }, // iPad mini Wi-Fi
+                { "iPad2,6", iOSChipType.A5 }, // iPad mini Wi-Fi + Cellular
+                { "iPad2,7", iOSChipType.A5 }, // iPad mini Wi-Fi + Cellular (MM)
+                { "iPad3,1", iOSChipType.A5 }, // iPad 3 Wi-Fi
+                { "iPad3,2", iOSChipType.A5 }, // iPad 3 Wi-Fi + Cellular (VZ)
+                { "iPad3,3", iOSChipType.A5X }, // iPad 3 Wi-Fi + Cellular
+                { "iPad3,4", iOSChipType.A6X }, // iPad 4 Wi-Fi
+                { "iPad3,5", iOSChipType.A6X }, // iPad 4 Wi-Fi + Cellular
+                { "iPad3,6", iOSChipType.A6X }, // iPad 4 Wi-Fi + Cellular (MM)
+                { "iPad4,1", iOSChipType.A7 }, // iPad Air Wi-Fi
+                { "iPad4,2", iOSChipType.A7 }, // iPad Air Wi-Fi + Cellular
+                { "iPad4,3", iOSChipType.A7 }, // iPad Air Wi-Fi + Cellular (TD-LTE)
+                { "iPad4,4", iOSChipType.A7 }, // iPad mini 2 Wi-Fi
+                { "iPad4,5", iOSChipType.A7 }, // iPad mini 2 Wi-Fi + Cellular
+                { "iPad4,6", iOSChipType.A7 }, // iPad mini 2 Wi-Fi + Cellular (TD-LTE)
+                { "iPad4,7", iOSChipType.A7 }, // iPad mini 3 Wi-Fi
+                { "iPad4,8", iOSChipType.A7 }, // iPad mini 3 Wi-Fi + Cellular
+                { "iPad4,9", iOSChipType.A7 }, // iPad mini 3 Wi-Fi + Cellular (TD-LTE)
+                { "iPad5,1", iOSChipType.A8 }, // iPad mini 4 Wi-Fi
+                { "iPad5,2", iOSChipType.A8 }, // iPad mini 4 Wi-Fi + Cellular
+                { "iPad5,3", iOSChipType.A8X }, // iPad Air 2 Wi-Fi
+                { "iPad5,4", iOSChipType.A8X }, // iPad Air 2 Wi-Fi + Cellular
+                { "iPad6,3", iOSChipType.A9X }, // iPad Pro 9.7" Wi-Fi
+                { "iPad6,4", iOSChipType.A9X }, // iPad Pro 9.7" Wi-Fi + Cellular
+                { "iPad6,7", iOSChipType.A9X }, // iPad Pro 12.9" Wi-Fi
+                { "iPad6,8", iOSChipType.A9X }, // iPad Pro 12.9" Wi-Fi + Cellular
+                { "iPad6,11", iOSChipType.A9 }, // iPad 5th gen Wi-Fi
+                { "iPad6,12", iOSChipType.A9 }, // iPad 5th gen Wi-Fi + Cellular
+                { "iPad7,1", iOSChipType.A10XFusion }, // iPad Pro 12.9" 2nd gen Wi-Fi
+                { "iPad7,2", iOSChipType.A10XFusion }, // iPad Pro 12.9" 2nd gen Wi-Fi + Cellular
+                { "iPad7,3", iOSChipType.A10XFusion }, // iPad Pro 10.5" Wi-Fi
+                { "iPad7,4", iOSChipType.A10XFusion }, // iPad Pro 10.5" Wi-Fi + Cellular
+                { "iPad7,5", iOSChipType.A10Fusion }, // iPad 9.7" 6th gen Wi-Fi
+                { "iPad7,6", iOSChipType.A10Fusion }, // iPad 9.7" 6th gen Wi-Fi + Cellular
+                { "iPad8,1", iOSChipType.A12XBionic }, // iPad Pro 11" Wi-Fi
+                { "iPad8,2", iOSChipType.A12XBionic }, // iPad Pro 11" Wi-Fi
+                { "iPad8,3", iOSChipType.A12XBionic }, // iPad Pro 11" Wi-Fi + Cellular
+                { "iPad8,4", iOSChipType.A12XBionic }, // iPad Pro 11" Wi-Fi + Cellular
+                { "iPad8,5", iOSChipType.A12XBionic }, // iPad Pro 12.9" 3nd gen Wi-Fi
+                { "iPad8,6", iOSChipType.A12XBionic }, // iPad Pro 12.9" 3nd gen Wi-Fi
+                { "iPad8,7", iOSChipType.A12XBionic }, // iPad Pro 12.9" 3nd gen Wi-Fi + Cellular
+                { "iPad8,8", iOSChipType.A12XBionic }, // iPad Pro 12.9" 3nd gen Wi-Fi + Cellular
+                { "iPad11,1", iOSChipType.A12Bionic }, // iPad mini 5 Wi-Fi
+                { "iPad11,2", iOSChipType.A12Bionic }, // iPad mini 5 Wi-Fi + Cellular
+                { "iPad11,3", iOSChipType.A12Bionic }, // iPad Air 3rd gen Wi-Fi
+                { "iPad11,4", iOSChipType.A12Bionic }, // iPad Air 3rd gen Wi-Fi + Cellular
+                { "iPod1,1", iOSChipType.A4 }, // iPod Touch
+                { "iPod2,1", iOSChipType.A4 }, // iPod Touch 2st gen
+                { "iPod3,1", iOSChipType.A4 }, // iPod Touch 3rd gen
+                { "iPod4,1", iOSChipType.A4 }, // iPod Touch 4th gen
+                { "iPod5,1", iOSChipType.A5 }, // iPod Touch 5th gen
+                { "iPod7,1", iOSChipType.A8 }, // iPod Touch 6th gen
+                { "iPod9,1", iOSChipType.A10Fusion }, // iPod Touch 7th gen
+            };
+        }
+
+        public iOSChipType GetChipType(string hardware) =>
+            modelChipMap.ContainsKey(hardware) ? modelChipMap[hardware] : iOSChipType.Unknown;
+    }
+}

--- a/iOSHardware.cs
+++ b/iOSHardware.cs
@@ -5,6 +5,16 @@ namespace Xamarin.iOS
     [Preserve(AllMembers = true)]
     class iOSHardware
     {
+        private readonly iOSChipTypeMap _chipTypeMap;
+
+        public iOSHardware()
+        {
+            _chipTypeMap = new iOSChipTypeMap();
+        }
+
+        public iOSChipType GetChipType(string hardware) =>
+            _chipTypeMap.GetChipType(hardware);
+
         public string GetModel(string hardware)
         {
             // https://support.apple.com/kb/HT3939


### PR DESCRIPTION
Adds a new property to determine the Apple Chip Type used by the device. It is a static mapping from hardware model identifer to an enum defining the known A-series chips used by Apple.

Solves #15 