### PR TITLE
Detect that iOS app is running on Mac hardware

### DIFF
--- a/Xamarin.iOS.DeviceHardware.cs
+++ b/Xamarin.iOS.DeviceHardware.cs
@@ -58,7 +58,7 @@ namespace Xamarin.iOS
             return "Unknown";
         }
 
-        public static string Version => FindVersion();
+        public static string Version => IsiOSAppOnMac() ? "mac" : FindVersion();
 
         public static iOSChipType ChipType
         {

--- a/Xamarin.iOS.DeviceHardware.cs
+++ b/Xamarin.iOS.DeviceHardware.cs
@@ -65,7 +65,11 @@ namespace Xamarin.iOS
             get
             {
                 var v = Version;
-                if (IsSimulator(v))
+                if (IsiOSAppOnMac())
+                {
+                    return iOSChipType.M1;
+                }
+                else if (IsSimulator(v))
                 {
                     return _hardwareMapper.GetChipType(SimulatorModel);
                 }
@@ -78,13 +82,20 @@ namespace Xamarin.iOS
             get
             {
                 var v = Version;
-                if (IsSimulator(v))
+                if (IsiOSAppOnMac())
+                {
+                    return "Mac";
+                }
+                else if (IsSimulator(v))
                 {
                     return _hardwareMapper.GetModel(SimulatorModel) + " Simulator";
                 }
                 return _hardwareMapper.GetModel(v);
             }
         }
+
+        private static bool IsiOSAppOnMac() =>
+            UIKit.UIDevice.CurrentDevice.CheckSystemVersion(14, 0) && NSProcessInfo.ProcessInfo.IsiOSApplicationOnMac;
 
         private static bool IsSimulator(string v) => v == "i386" || v == "x86_64";
 

--- a/Xamarin.iOS.DeviceHardware.cs
+++ b/Xamarin.iOS.DeviceHardware.cs
@@ -65,11 +65,7 @@ namespace Xamarin.iOS
             get
             {
                 var v = Version;
-                if (IsiOSAppOnMac())
-                {
-                    return iOSChipType.AppleSiliconMac;
-                }
-                else if (IsSimulator(v))
+                if (IsSimulator(v))
                 {
                     return _hardwareMapper.GetChipType(SimulatorModel);
                 }
@@ -82,11 +78,7 @@ namespace Xamarin.iOS
             get
             {
                 var v = Version;
-                if (IsiOSAppOnMac())
-                {
-                    return "Mac";
-                }
-                else if (IsSimulator(v))
+                if (IsSimulator(v))
                 {
                     return _hardwareMapper.GetModel(SimulatorModel) + " Simulator";
                 }

--- a/Xamarin.iOS.DeviceHardware.cs
+++ b/Xamarin.iOS.DeviceHardware.cs
@@ -67,7 +67,7 @@ namespace Xamarin.iOS
                 var v = Version;
                 if (IsiOSAppOnMac())
                 {
-                    return iOSChipType.M1;
+                    return iOSChipType.AppleSiliconMac;
                 }
                 else if (IsSimulator(v))
                 {

--- a/iOSChipType.cs
+++ b/iOSChipType.cs
@@ -21,6 +21,6 @@
         A12ZBionic,
         A13Bionic,
         A14Bionic,
-        M1
+        AppleSiliconMac
     }
 }

--- a/iOSChipType.cs
+++ b/iOSChipType.cs
@@ -20,6 +20,7 @@
         A12XBionic,
         A12ZBionic,
         A13Bionic,
-        A14Bionic
+        A14Bionic,
+        M1
     }
 }

--- a/iOSChipType.cs
+++ b/iOSChipType.cs
@@ -21,6 +21,6 @@
         A12ZBionic,
         A13Bionic,
         A14Bionic,
-        AppleSiliconMac
+        AppleSiliconMac,
     }
 }

--- a/iOSChipTypeMap.cs
+++ b/iOSChipTypeMap.cs
@@ -115,7 +115,8 @@ namespace Xamarin.iOS
                 { "iPod4,1", iOSChipType.A4 }, // iPod Touch 4th gen
                 { "iPod5,1", iOSChipType.A5 }, // iPod Touch 5th gen
                 { "iPod7,1", iOSChipType.A8 }, // iPod Touch 6th gen
-                { "iPod9,1", iOSChipType.A10Fusion }, // iPod Touch 7th gen
+                { "iPod9,1", iOSChipType.A10Fusion }, // iPod Touch 7th gen,
+                { "mac", iOSChipType.AppleSiliconMac }, // iOS app running on Apple Silicon Mac
             };
         }
 

--- a/iOSChipTypeMap.cs
+++ b/iOSChipTypeMap.cs
@@ -115,7 +115,7 @@ namespace Xamarin.iOS
                 { "iPod4,1", iOSChipType.A4 }, // iPod Touch 4th gen
                 { "iPod5,1", iOSChipType.A5 }, // iPod Touch 5th gen
                 { "iPod7,1", iOSChipType.A8 }, // iPod Touch 6th gen
-                { "iPod9,1", iOSChipType.A10Fusion }, // iPod Touch 7th gen,
+                { "iPod9,1", iOSChipType.A10Fusion }, // iPod Touch 7th gen
                 { "mac", iOSChipType.AppleSiliconMac }, // iOS app running on Apple Silicon Mac
             };
         }

--- a/iOSHardware.cs
+++ b/iOSHardware.cs
@@ -249,6 +249,9 @@ namespace Xamarin.iOS
             if (hardware == "i386" || hardware == "x86_64")
                 return "Simulator";
 
+            if (hardware == "mac")
+                return "Mac";
+
             return (hardware == "" ? "Unknown" : hardware);
         }
     }


### PR DESCRIPTION
Solve #26 by adding support for iOS apps running on Mac hardware. The iOS 14 API `NSProcessInfo.ProcessInfo.IsiOSApplicationOnMac` is used to determine if the app is running on a Mac. 

When running on a Mac the following values are returned:

- Version: `mac`
- Model: `Mac`
- ChipType: `AppleSiliconMac`

The more generic chip name `AppleSiliconMac` was selected as I do not think we ever will be able to determine the actual underlying hardware for an iOS app executing on Mac hardware (the `hw.machine` returns ipad8,6 as its fallback/compatibility value).

One could argue that this PR should also keep `ipad8,6` as its version string, or not try to be smart about the model name. But at the same time, it does feel similar to how the library handles Simulator as a special case.