### PR TITLE
Added new iPad Pro's model and fixed missing chip names.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Will keep repository updated as new devices become available.
 If you need an Android library check out my other repo https://github.com/dannycabrera/GetDroidModel.
 
 Updates:<br/>
+20210529 - Added new iPad models: iPad Pro (11-inch) (3rd generation) and iPad Pro (12.9-inch) (5th generation), corrected/added missing from iPad11,6 to iPad13,2's chip name.<br/>
 20201212 - Added latest iPad and iPhone models<br/>
 20200404 - Added iPhone SE (2nd generation)<br/>
 20200327 - Added new iPad models iPad Pro 11-inch (2nd generation) and iPad Pro 12.9-inch (4th generation)<br/>
@@ -76,4 +77,4 @@ Result: "A6"
 *******
 Thanks to:
 -------
-@sven-s, @manishkungwani, @jimbobbennett, @adamzucchi and @follesoe for their pull requests.
+@sven-s, @manishkungwani, @jimbobbennett, @adamzucchi, @follesoe and @CoreNion for their pull requests.

--- a/iOSChipType.cs
+++ b/iOSChipType.cs
@@ -21,6 +21,7 @@
         A12ZBionic,
         A13Bionic,
         A14Bionic,
+        A15Bionic,
         M1
     }
 }

--- a/iOSChipType.cs
+++ b/iOSChipType.cs
@@ -20,6 +20,7 @@
         A12XBionic,
         A12ZBionic,
         A13Bionic,
-        A14Bionic
+        A14Bionic,
+        M1
     }
 }

--- a/iOSChipTypeMap.cs
+++ b/iOSChipTypeMap.cs
@@ -109,6 +109,18 @@ namespace Xamarin.iOS
                 { "iPad11,2", iOSChipType.A12Bionic }, // iPad mini 5 Wi-Fi + Cellular
                 { "iPad11,3", iOSChipType.A12Bionic }, // iPad Air 3rd gen Wi-Fi
                 { "iPad11,4", iOSChipType.A12Bionic }, // iPad Air 3rd gen Wi-Fi + Cellular
+                { "iPad11,6", iOSChipType.A12Bionic }, // iPad (8th Generation) Wi-Fi
+                { "iPad11,7", iOSChipType.A12Bionic }, // iPad (8th Generation) Wi-Fi + Cellular
+                { "iPad13,1", iOSChipType.A14Bionic }, // iPad Air (4th generation) Wi-Fi
+                { "iPad13,2", iOSChipType.A14Bionic }, // iPad Air (4th generation) Wi-Fi + Cellular
+                { "iPad13,4", iOSChipType.M1 }, // iPad Pro (11-inch) (3rd generation) Wi-Fi
+                { "iPad13,5", iOSChipType.M1 }, // iPad Pro (11-inch) (3rd generation) Wi-Fi
+                { "iPad13,6", iOSChipType.M1 }, // iPad Pro (11-inch) (3rd generation) Wi-Fi + Cellular
+                { "iPad13,7", iOSChipType.M1 }, // iPad Pro (11-inch) (3rd generation) Wi-Fi + Cellular
+                { "iPad13,8", iOSChipType.M1 }, // iPad Pro (12.9-inch) (5th generation) Wi-Fi
+                { "iPad13,9", iOSChipType.M1 }, // iPad Pro (12.9-inch) (5th generation) Wi-Fi
+                { "iPad13,10", iOSChipType.M1 }, // iPad Pro (12.9-inch) (5th generation) Wi-Fi + Cellular
+                { "iPad13,11", iOSChipType.M1 }, // iPad Pro (12.9-inch) (5th generation) Wi-Fi + Cellular
                 { "iPod1,1", iOSChipType.A4 }, // iPod Touch
                 { "iPod2,1", iOSChipType.A4 }, // iPod Touch 2st gen
                 { "iPod3,1", iOSChipType.A4 }, // iPod Touch 3rd gen

--- a/iOSChipTypeMap.cs
+++ b/iOSChipTypeMap.cs
@@ -52,6 +52,10 @@ namespace Xamarin.iOS
                 { "iPhone13,2", iOSChipType.A14Bionic }, // iPhone 12
                 { "iPhone13,3", iOSChipType.A14Bionic }, // iPhone 12 Pro
                 { "iPhone13,4", iOSChipType.A14Bionic }, // iPhone 12 Pro Max
+                { "iPhone14,2", iOSChipType.A15Bionic }, // iPhone 13 Pro
+                { "iPhone14,3", iOSChipType.A15Bionic }, // iPhone 13 Pro Max
+                { "iPhone14,4", iOSChipType.A15Bionic }, // iPhone 13 mini
+                { "iPhone14,5", iOSChipType.A15Bionic }, // iPhone 13
                 { "iPad1,1", iOSChipType.A4 }, // iPad
                 { "iPad2,1", iOSChipType.A5 }, // iPad 2 Wi-Fi
                 { "iPad2,2", iOSChipType.A5 }, // iPad 2 GSM
@@ -111,6 +115,8 @@ namespace Xamarin.iOS
                 { "iPad11,4", iOSChipType.A12Bionic }, // iPad Air 3rd gen Wi-Fi + Cellular
                 { "iPad11,6", iOSChipType.A12Bionic }, // iPad (8th Generation) Wi-Fi
                 { "iPad11,7", iOSChipType.A12Bionic }, // iPad (8th Generation) Wi-Fi + Cellular
+                { "iPad12,1", iOSChipType.A13Bionic }, // iPad (9th Generation) Wi-Fi
+                { "iPad12,2", iOSChipType.A13Bionic }, // iPad (9th Generation) Wi-Fi + Cellular
                 { "iPad13,1", iOSChipType.A14Bionic }, // iPad Air (4th generation) Wi-Fi
                 { "iPad13,2", iOSChipType.A14Bionic }, // iPad Air (4th generation) Wi-Fi + Cellular
                 { "iPad13,4", iOSChipType.M1 }, // iPad Pro (11-inch) (3rd generation) Wi-Fi
@@ -121,6 +127,8 @@ namespace Xamarin.iOS
                 { "iPad13,9", iOSChipType.M1 }, // iPad Pro (12.9-inch) (5th generation) Wi-Fi
                 { "iPad13,10", iOSChipType.M1 }, // iPad Pro (12.9-inch) (5th generation) Wi-Fi + Cellular
                 { "iPad13,11", iOSChipType.M1 }, // iPad Pro (12.9-inch) (5th generation) Wi-Fi + Cellular
+                { "iPad14,1", iOSChipType.A15Bionic }, // iPad mini 5 Wi-Fi
+                { "iPad14,2", iOSChipType.A15Bionic }, // iPad mini 5 Wi-Fi + Cellular
                 { "iPod1,1", iOSChipType.A4 }, // iPod Touch
                 { "iPod2,1", iOSChipType.A4 }, // iPod Touch 2st gen
                 { "iPod3,1", iOSChipType.A4 }, // iPod Touch 3rd gen

--- a/iOSHardware.cs
+++ b/iOSHardware.cs
@@ -121,6 +121,22 @@ namespace Xamarin.iOS
             {
                 switch (hardware)
                 {
+                    case "iPad13,11":
+                        return "iPad Pro (12.9-inch) (5th generation) Wi-Fi + Cellular";
+                    case "iPad13,10":
+                        return "iPad Pro (12.9-inch) (5th generation) Wi-Fi + Cellular";
+                    case "iPad13,9":
+                        return "iPad Pro (12.9-inch) (5th generation) Wi-Fi";
+                    case "iPad13,8":
+                        return "iPad Pro (12.9-inch) (5th generation) Wi-Fi";
+                    case "iPad13,7":
+                        return "iPad Pro (11-inch) (3rd generation) Wi-Fi + Cellular";
+                    case "iPad13,6":
+                        return "iPad Pro (11-inch) (3rd generation) Wi-Fi + Cellular";
+                    case "iPad13,5":
+                        return "iPad Pro (11-inch) (3rd generation) Wi-Fi";
+                    case "iPad13,4":
+                        return "iPad Pro (11-inch) (3rd generation) Wi-Fi";
                     case "iPad13,2":
                         return "iPad Air (4th generation) Wi-Fi + Cellular";
                     case "iPad13,1":

--- a/iOSHardware.cs
+++ b/iOSHardware.cs
@@ -20,6 +20,14 @@ namespace Xamarin.iOS
             {
                 switch (hardware)
                 {
+                    case "iPhone14,2":
+                        return "iPhone 13 Pro";
+                    case "iPhone14,3":
+                        return "iPhone 13 Pro Max";
+                    case "iPhone14,4":
+                        return "iPhone 13 mini";
+                    case "iPhone14,5":
+                        return "iPhone 13";
                     case "iPhone13,1":
                         return "iPhone 12 mini";
                     case "iPhone13,2":
@@ -121,6 +129,10 @@ namespace Xamarin.iOS
             {
                 switch (hardware)
                 {
+                    case "iPad14,2":
+                        return "iPad mini (6th generation) Wi-FI + Cellular";
+                    case "iPad14,1":
+                        return "iPad mini (6th generation) Wi-FI";
                     case "iPad13,11":
                         return "iPad Pro (12.9-inch) (5th generation) Wi-Fi + Cellular";
                     case "iPad13,10":
@@ -141,6 +153,10 @@ namespace Xamarin.iOS
                         return "iPad Air (4th generation) Wi-Fi + Cellular";
                     case "iPad13,1":
                         return "iPad Air (4th generation) Wi-Fi";
+                    case "iPad12,2":
+                        return "iPad (9th Generation) Wi-Fi + Cellular";
+                    case "iPad12,1":
+                        return "iPad (9th generation) Wi-Fi";
                     case "iPad11,7":
                         return "iPad (8th Generation) Wi-Fi + Cellular";
                     case "iPad11,6":


### PR DESCRIPTION
I added new iPad Pro's model name.

Also, I Corrected missing chip names for iPad Air (4th gen) and iPad (8th gen).